### PR TITLE
Fix notification when changing to private-post later

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,7 @@ class ApplicationController < ActionController::Base
   def set_notifications
     @notifications = current_user.passive_notifications
                     .where.not(visitor_id: current_user.id)
+                    .where(is_active: true)
                     .includes(:visitor, :post, :post_comment, :message)
                     .order(created_at: :desc)
                     .page(params[:page]).per(25) # サイドバー用に最新25件だけ取得

--- a/app/controllers/public/post_comments_controller.rb
+++ b/app/controllers/public/post_comments_controller.rb
@@ -12,7 +12,9 @@ class Public::PostCommentsController < ApplicationController
     @post_comments = PostComment.where(post_id: post.id)
     @post_comment = current_user.post_comments.new(post_comment_params.merge(post_id: params[:post_id]))
     if @post_comment.save
-      @post_comment.create_notification_post_comment(current_user, @post_comment.id)
+      if post.is_public == true
+        @post_comment.create_notification_post_comment(current_user, @post_comment.id)
+      end
     else
       redirect_to request.referer, alert: 'コメントの送信に失敗しました'
     end

--- a/app/controllers/public/posts_controller.rb
+++ b/app/controllers/public/posts_controller.rb
@@ -64,6 +64,11 @@ class Public::PostsController < ApplicationController
   def update
     post = Post.find(params[:id])
     if post.update(post_params)
+      if params[:post][:is_public] == "false"
+        post.update_notification_is_active(false, current_user)
+      elsif params[:post][:is_public] == "true"
+        post.update_notification_is_active(true, current_user)
+      end
       redirect_to post_path(post.id), notice: '投稿を編集しました'
     else
       redirect_to edit_post_path(post.id), alert: '投稿の編集に失敗しました'

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -44,4 +44,15 @@ class Post < ApplicationRecord
       notification.save if notification.valid?
     end
   end
+
+  def update_notification_is_active(new_value, current_user)
+    if new_value == false
+      # 自分以外の関連する通知のis_activeをfalseにする
+      notifications.where(post_id: id).where.not(visited_id: current_user.id).update_all(is_active: false)
+    else
+      # 再び公開された場合、自分以外の関連する通知のis_activeをtrueにする
+      notifications.where(post_id: id).where.not(visited_id: current_user.id).update_all(is_active: true)
+    end
+    update(is_public: new_value)
+  end
 end

--- a/app/views/public/notifications/_link_in_notification.html.erb
+++ b/app/views/public/notifications/_link_in_notification.html.erb
@@ -4,29 +4,27 @@
 <div class="container px-1">
   <div class="m-2 p-1" style="border-radius: 15px; background-color: <%= notification.checked ? '#fafafa' : '#eaffd0' %>;">
     <div class="d-flex align-items-center">
-      <div>
-        <span style="font-size: 13px;">
-          <%= link_to user_path(visitor) do %>
-            <%= image_tag visitor.get_image(25, 25), class: "rounded-circle", style: "height: 25px; width: 25px;" %>
-          <% end %>
-          <%# 改行がスペースを生むため、spanの中身を横一列に記述 %>
-          <% case notification.action %>
-          <% when 'follow' %>
-            <%= link_to "#{visitor.name}さん", user_path(visitor), style: 'font-weight: bold;' %><%= "があなたをフォローしました" %>
-          <% when 'favorite' %>
-            <%= link_to "#{visitor.name}さん", user_path(visitor), style: 'font-weight: bold;' %><%= "が" %><%= link_to 'あなたの投稿', notification.post, style: 'font-weight: bold;' %><%= "にいいねしました" %>
-          <% when 'post_comment' %>
-            <% if notification.post.user_id == visited.id %>
-              <%= link_to "#{visitor.name}さん", user_path(visitor), style: 'font-weight: bold;' %><%= "が" %><%= link_to 'あなたの投稿', notification.post, style: 'font-weight: bold;' %><%= "にコメントしました" %>
-            <% else %>
-              <%= link_to "#{visitor.name}さん", user_path(visitor), style: 'font-weight: bold;' %><%= "が" %><%= link_to notification.post.user.name, user_path(notification.post.user) %><%= "さんの" %><%= link_to "投稿", notification.post %><%= "にコメントしました" %>
-            <% end %>
-          <% when 'message' %>
-            <%= link_to "#{visitor.name}さん", user_path(visitor), style: 'font-weight: bold;' %><%= "から" %><%= link_to 'メッセージ', room_path(notification.message.room), style: 'font-weight: bold;' %><%= "があります" %>
+      <div style="font-size: 13px; line-height: 25px;">
+        <%= link_to user_path(visitor) do %>
+          <%= image_tag visitor.get_image(25, 25), class: "rounded-circle", style: "height: 25px; width: 25px;" %>
+        <% end %>
+        <%# 改行がスペースを生むため、spanの中身を横一列に記述 %>
+        <% case notification.action %>
+        <% when 'follow' %>
+          <%= link_to "#{visitor.name}さん", user_path(visitor), style: 'font-weight: bold;' %><%= "があなたをフォローしました" %>
+        <% when 'favorite' %>
+          <%= link_to "#{visitor.name}さん", user_path(visitor), style: 'font-weight: bold;' %><%= "が" %><%= link_to 'あなたの投稿', notification.post, style: 'font-weight: bold;' %><%= "にいいねしました" %>
+        <% when 'post_comment' %>
+          <% if notification.post.user_id == visited.id %>
+            <%= link_to "#{visitor.name}さん", user_path(visitor), style: 'font-weight: bold;' %><%= "が" %><%= link_to 'あなたの投稿', notification.post, style: 'font-weight: bold;' %><%= "にコメントしました" %>
           <% else %>
-            <%= "通知内容が不明です" %>
+            <%= link_to "#{visitor.name}さん", user_path(visitor), style: 'font-weight: bold;' %><%= "が" %><%= link_to notification.post.user.name, user_path(notification.post.user) %><%= "さんの" %><%= link_to "投稿", notification.post %><%= "にコメントしました" %>
           <% end %>
-        </span>
+        <% when 'message' %>
+          <%= link_to "#{visitor.name}さん", user_path(visitor), style: 'font-weight: bold;' %><%= "から" %><%= link_to 'メッセージ', room_path(notification.message.room), style: 'font-weight: bold;' %><%= "があります" %>
+        <% else %>
+          <%= "通知内容が不明です" %>
+        <% end %>
       </div>
     </div>
 

--- a/db/migrate/20241107110511_create_notifications.rb
+++ b/db/migrate/20241107110511_create_notifications.rb
@@ -10,6 +10,7 @@ class CreateNotifications < ActiveRecord::Migration[6.1]
       t.integer :message_id
       t.string :action, null: false, default: ''
       t.boolean :checked, null: false, default: false
+      t.boolean :is_active, null: true, default: true
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -100,6 +100,7 @@ ActiveRecord::Schema.define(version: 2024_11_07_110511) do
     t.integer "message_id"
     t.string "action", default: "", null: false
     t.boolean "checked", default: false, null: false
+    t.boolean "is_active", default: true
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end


### PR DESCRIPTION
notificationに:is_activeを追加
投稿が後から非公開に変更された際に他ユーザーがpost_commentの通知からアクセスできなくなるため、投稿者以外の持つ関連する通知が一覧から非表示になるよう変更